### PR TITLE
BUGFIX: Typo in autoloader config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "GPL-3.0-or-later",
     "autoload": {
         "psr-4": {
-            "Siegeist\\Stencil\\": "Classes/"
+            "Sitegeist\\Stencil\\": "Classes/"
         }
     },
     "extra": {


### PR DESCRIPTION
This didn't cause an error, but the fix might keep someone from a debugging session later on :)